### PR TITLE
Fix duplicate path import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,6 @@ const app = express();
 
 // View-Engine & Static
 app.set('view engine', 'ejs');
-const path = require('path');
 app.set('views', path.join(__dirname, 'views'));
 app.locals.basedir = app.get('views');
 app.use(express.urlencoded({ extended: true }));


### PR DESCRIPTION
## Summary
- fix a programming bug in `src/index.js` by removing a duplicate `require('path')`

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867e8c52bfc832ea60467181f035702