### PR TITLE
Add login test setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "node src/index.js"
+    "start": "node src/index.js",
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -17,5 +18,9 @@
     "express-session": "^1.18.1",
     "sqlite3": "^5.1.7",
     "pg": "^8.10.0"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "supertest": "^6.3.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,18 @@
 require('dotenv').config();
 const express = require('express');
 const session = require('express-session');
-const path    = require('path');
-const db      = require('./db');
+const path = require('path');
+const db = require('./db');
 
 // Routen importieren
-const authRoutes  = require('./routes/auth');
-const transactionRoutes    = require('./routes/transactions');        // Achtung: hier korrigieren wir gleich auf './routes/transactions'
+const authRoutes = require('./routes/auth');
+const transactionRoutes = require('./routes/transactions');
 const adminRoutes = require('./routes/admin');
 
 const app = express();
 
 // View-Engine & Static
 app.set('view engine', 'ejs');
-const path = require('path');
 app.set('views', path.join(__dirname, 'views'));
 app.locals.basedir = app.get('views');
 app.use(express.urlencoded({ extended: true }));
@@ -37,8 +36,11 @@ app.use('/', authRoutes);
 app.use('/transactions', transactionRoutes);
 app.use('/admin', adminRoutes);
 
-// Server starten
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, '0.0.0.0', () => {
-  console.log(`Server läuft auf http://0.0.0.0:${PORT}`);
-});
+if (require.main === module) {
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, '0.0.0.0', () => {
+    console.log(`Server läuft auf http://0.0.0.0:${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,35 @@
+const request = require('supertest');
+const bcrypt = require('bcrypt');
+
+// Mock the database module before requiring the app
+jest.mock('../src/db', () => ({
+  query: jest.fn()
+}));
+
+const db = require('../src/db');
+let app;
+
+beforeAll(async () => {
+  const hash = await bcrypt.hash('1234', 10);
+  db.query.mockImplementation((text, params) => {
+    if (text.includes('SELECT id, vorname, pin_hash FROM users')) {
+      return Promise.resolve({ rows: [{ id: 1, vorname: 'Emily', pin_hash: hash }] });
+    }
+    return Promise.resolve({ rows: [] });
+  });
+  app = require('../src/index');
+});
+
+describe('Authentication', () => {
+  test('POST /login with valid credentials redirects and sets session cookie', async () => {
+    const res = await request(app)
+      .post('/login')
+      .type('form')
+      .send({ vorname: 'Emily', pin: '1234' });
+
+    expect(res.status).toBe(302);
+    expect(res.headers['location']).toBe('/balance');
+    const cookies = res.headers['set-cookie'] || [];
+    expect(cookies.some(c => c.startsWith('connect.sid='))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `jest` and `supertest` dev dependencies
- export Express `app` from `src/index.js`
- create `tests/auth.test.js` with login test
- add `npm test` script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ea0739f4832e8f9610e1506ad848