### PR TITLE
Fix duplicate path import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,6 @@ const app = express();
 
 // View-Engine & Static
 app.set('view engine', 'ejs');
-const path = require('path');
 app.set('views', path.join(__dirname, 'views'));
 app.locals.basedir = app.get('views');
 app.use(express.urlencoded({ extended: true }));


### PR DESCRIPTION
## Summary
- remove redundant `path` import in `src/index.js`

## Testing
- `node --check src/index.js`
- `node src/index.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6867e9effdc0832ea3e3795ac271f578