### PR TITLE
Fix error message spelling in admin transactions

### DIFF
--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -51,7 +51,7 @@ router.post('/transactions/new', requireAdmin, async (req, res) => {
   } catch (err) {
     console.error(err);
     const { rows: users } = await db.query('SELECT id, vorname FROM users');
-    res.render('admin/new-transaction', { title: 'Login', users, error: 'Speicher-Fehler' });
+    res.render('admin/new-transaction', { title: 'Login', users, error: 'Speicherfehler' });
   }
 });
 


### PR DESCRIPTION
## Summary
- correct spelling of 'Speicherfehler' in admin route

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867e9ebdc24832e8836744b8f1bb243