### PR TITLE
Fix admin login route

### DIFF
--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -8,7 +8,7 @@ function requireAdmin(req, res, next) {
 }
 
 router.get('/login', (req, res) => {
-  res.render('admin/login', { error: null });
+  res.render('admin/login', { title: 'Login', error: null });
 });
 
 router.post('/login', (req, res) => {

--- a/src/views/admin/edit-transaction.ejs
+++ b/src/views/admin/edit-transaction.ejs
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
-<%- include('/partials/head') %>
+<%- include('../partials/head') %>
 <body class="bg-gray-50 text-gray-800">
-  <%- include('/partials/header') %>
+  <%- include('../partials/header') %>
 
   <% if (error) { %>
     <p style="color:red"><%= error %></p>

--- a/src/views/admin/login.ejs
+++ b/src/views/admin/login.ejs
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
-<%- include('/partials/head') %>
+<%- include('../partials/head') %>
 <body class="bg-gray-50 text-gray-800">
-  <%- include('/partials/header') %>
+  <%- include('../partials/header') %>
   <% if (error) { %><p><%= error %></p><% } %>
   <form action="/admin/login" method="post">
     <input name="username" placeholder="Admin-Benutzer" required />

--- a/src/views/admin/new-transaction.ejs
+++ b/src/views/admin/new-transaction.ejs
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
-<%- include('/partials/head') %>
+<%- include('../partials/head') %>
 <body class="bg-gray-50 text-gray-800">
-  <%- include('/partials/header') %>
+  <%- include('../partials/header') %>
   <% if (error) { %><p><%= error %></p><% } %>
   <form action="/admin/transactions/new" method="post">
     <select name="user_id" required>

--- a/src/views/admin/transactions.ejs
+++ b/src/views/admin/transactions.ejs
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
-<%- include('/partials/head') %>
+<%- include('../partials/head') %>
 <body class="bg-gray-50 text-gray-800">
-  <%- include('/partials/header') %>
+  <%- include('../partials/header') %>
   <h1>Transaktionen verwalten</h1>
   <a href="/admin/transactions/new">→ Neue Transaktion</a> |
   <a href="/admin/logout">Logout</a>

--- a/src/views/balance.ejs
+++ b/src/views/balance.ejs
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
-<%- include('/partials/head') %>
+<%- include('./partials/head') %>
 <body class="bg-gray-50 text-gray-800">
-  <%- include('/partials/header') %>
+  <%- include('./partials/header') %>
   <h1 style="text-align:center; font-size:4rem;">
     Saldo: <%= balance.toFixed(2) %> €
   </h1>

--- a/src/views/login.ejs
+++ b/src/views/login.ejs
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
-<%- include('/partials/head') %>
+<%- include('./partials/head') %>
 <body class="bg-gray-50 text-gray-800">
-  <%- include('/partials/header') %>
+  <%- include('./partials/header') %>
   <% if (error) { %><p><%= error %></p><% } %>
   <form action="/login" method="post">
     <input name="vorname"    placeholder="Vorname" required />

--- a/src/views/transactions.ejs
+++ b/src/views/transactions.ejs
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="de">
-<%- include('/partials/head') %>
+<%- include('./partials/head') %>
 <body class="bg-gray-50 text-gray-800">
-  <%- include('/partials/header') %>
+  <%- include('./partials/header') %>
   <% if (typeof error !== 'undefined' && error) { %><p><%= error %></p><% } %>
   <ul>
     <% transactions.forEach(tx => { %>


### PR DESCRIPTION
## Summary
- render admin login with title to match head.ejs expectations

## Testing
- `npm test` *(fails: Missing script)*
- `node src/index.js` *(fails: ECONNREFUSED because Postgres isn't running)*

------
https://chatgpt.com/codex/tasks/task_e_6867ecf34f4c832e83df9288c07fdecc