### PR TITLE
Add admin overview and user specific management

### DIFF
--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -18,24 +18,41 @@ router.post('/login', (req, res) => {
     password === process.env.ADMIN_PASS
   ) {
     req.session.admin = true;
-    return res.redirect('/admin/transactions/new');
+    return res.redirect('/admin');
   }
-  res.render('admin/login', { title: 'Login', error: 'Ungültige Zugangsdaten' });
+  res.render('admin/login', { title: 'Login', error: 'Ung\u00fcltige Zugangsdaten' });
 });
 
-// Formular für neue Transaktion (neu)
+// \u00dcbersicht aller Saldos
+router.get('/', requireAdmin, async (req, res) => {
+  try {
+    const { rows } = await db.query(`
+      SELECT u.id, u.vorname,
+             COALESCE(SUM(CASE WHEN t.type='debt' THEN t.amount ELSE -t.amount END),0) AS balance
+        FROM users u
+        LEFT JOIN transactions t ON t.user_id = u.id
+       GROUP BY u.id
+       ORDER BY u.vorname`);
+    const users = rows.map(r => ({
+      id: r.id,
+      vorname: r.vorname,
+      balance: parseFloat(r.balance)
+    }));
+    res.render('admin/overview', { title: 'Login', users });
+  } catch (err) {
+    console.error('Admin GET / Error:', err);
+    res.status(500).send(`<h1>500 \u2013 Serverfehler</h1><pre>${err.stack}</pre>`);
+  }
+});
+
+// Formular f\u00fcr neue Transaktion (global)
 router.get('/transactions/new', requireAdmin, async (req, res) => {
   try {
-    // 1) Alle Nutzer aus Postgres holen
-    const { rows: users } = await db.query(
-      'SELECT id, vorname FROM users ORDER BY vorname',
-      []
-    );
-    // 2) Rendern
-    res.render('admin/new-transaction', { title: 'Login', users, error: null });
+    const { rows: users } = await db.query('SELECT id, vorname FROM users ORDER BY vorname');
+    res.render('admin/new-transaction', { title: 'Login', users, error: null, selectedUserId: null, formAction: '/admin/transactions/new' });
   } catch (err) {
     console.error('Fehler beim Laden des New-Transaction-Formulars:', err);
-    res.render('admin/new-transaction', { title: 'Login', users: [], error: 'Datenbankfehler' });
+    res.render('admin/new-transaction', { title: 'Login', users: [], error: 'Datenbankfehler', selectedUserId: null, formAction: '/admin/transactions/new' });
   }
 });
 
@@ -50,12 +67,77 @@ router.post('/transactions/new', requireAdmin, async (req, res) => {
     res.redirect('/admin/transactions');
   } catch (err) {
     console.error(err);
-    const { rows: users } = await db.query('SELECT id, vorname FROM users');
-    res.render('admin/new-transaction', { title: 'Login', users, error: 'Speicherfehler' });
+    const { rows: users } = await db.query('SELECT id, vorname FROM users ORDER BY vorname');
+    res.render('admin/new-transaction', { title: 'Login', users, error: 'Speicherfehler', selectedUserId: null, formAction: '/admin/transactions/new' });
   }
 });
 
-// Admin: Liste aller Transaktionen mit direkter Fehleranzeige
+// neue Transaktion f\u00fcr bestimmten Nutzer
+router.get('/users/:userId/transactions/new', requireAdmin, async (req, res) => {
+  const userId = req.params.userId;
+  try {
+    const { rows: users } = await db.query('SELECT id, vorname FROM users ORDER BY vorname');
+    res.render('admin/new-transaction', {
+      title: 'Login',
+      users,
+      error: null,
+      selectedUserId: parseInt(userId,10),
+      formAction: `/admin/users/${userId}/transactions/new`
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).send(`<h1>500 \u2013 Serverfehler</h1><pre>${err.stack}</pre>`);
+  }
+});
+
+router.post('/users/:userId/transactions/new', requireAdmin, async (req, res) => {
+  const userId = req.params.userId;
+  try {
+    const { type, amount, date } = req.body;
+    await db.query(
+      `INSERT INTO transactions(user_id, type, amount, date)
+       VALUES($1, $2, $3, $4)`,
+      [userId, type, amount, date]
+    );
+    res.redirect(`/admin/users/${userId}/transactions`);
+  } catch (err) {
+    console.error(err);
+    const { rows: users } = await db.query('SELECT id, vorname FROM users ORDER BY vorname');
+    res.render('admin/new-transaction', {
+      title: 'Login',
+      users,
+      error: 'Speicherfehler',
+      selectedUserId: parseInt(userId,10),
+      formAction: `/admin/users/${userId}/transactions/new`
+    });
+  }
+});
+
+// Liste der Transaktionen f\u00fcr bestimmten Nutzer
+router.get('/users/:userId/transactions', requireAdmin, async (req, res) => {
+  const userId = req.params.userId;
+  try {
+    const { rows: userRows } = await db.query('SELECT vorname FROM users WHERE id=$1', [userId]);
+    if (userRows.length === 0) return res.status(404).send('<h1>404 \u2013 Nutzer nicht gefunden</h1>');
+    const user = { id: userId, vorname: userRows[0].vorname };
+    const { rows } = await db.query(
+      'SELECT id, date, type, amount FROM transactions WHERE user_id=$1 ORDER BY date DESC',
+      [userId]
+    );
+    const transactions = rows.map(tx => ({
+      id: tx.id,
+      date: new Date(tx.date).toLocaleString('de-DE', { dateStyle: 'short', timeStyle: 'short', timeZone: 'Europe/Berlin' }),
+      type: tx.type,
+      amount: parseFloat(tx.amount)
+    }));
+    res.render('admin/user-transactions', { title: 'Login', user, transactions });
+  } catch (err) {
+    console.error(err);
+    res.status(500).send(`<h1>500 \u2013 Serverfehler</h1><pre>${err.stack}</pre>`);
+  }
+});
+
+// Admin: Liste aller Transaktionen (bestehend)
 router.get('/transactions', requireAdmin, async (req, res) => {
   try {
     const { rows } = await db.query(`
@@ -64,7 +146,6 @@ router.get('/transactions', requireAdmin, async (req, res) => {
       JOIN users u ON t.user_id = u.id
       ORDER BY t.date DESC
     `);
-        // amount als Zahl umwandeln, damit toFixed klappt
     const transactions = rows.map(tx => ({
       id:      tx.id,
       date:    tx.date,
@@ -75,41 +156,39 @@ router.get('/transactions', requireAdmin, async (req, res) => {
     res.render('admin/transactions', { title: 'Login', transactions, error: null });
   } catch (err) {
     console.error('Admin GET /transactions Error:', err);
-    // Zeige den Stack direkt im Browser:
-    return res.status(500).send(`<h1>500 – Serverfehler</h1><pre>${err.stack}</pre>`);
+    return res.status(500).send(`<h1>500 \u2013 Serverfehler</h1><pre>${err.stack}</pre>`);
   }
 });
 
-// 2) Bearbeitungs-Formular anzeigen
-// Debug-GET für Transaktion bearbeiten
+// Bearbeitungs-Formular anzeigen
 router.get('/transactions/:id/edit', requireAdmin, async (req, res) => {
   try {
     const id = req.params.id;
-    const { rows } = await db.query(
-      'SELECT * FROM transactions WHERE id = $1',
-      [id]
-    );
+    const returnUser = req.query.user;
+    const { rows } = await db.query('SELECT * FROM transactions WHERE id = $1', [id]);
     if (rows.length === 0) {
-      return res.status(404).send(`<h1>404 – Nicht gefunden</h1>`);
+      return res.status(404).send('<h1>404 \u2013 Nicht gefunden</h1>');
     }
     const tx = rows[0];
-    const { rows: users } = await db.query(
-      'SELECT id, vorname FROM users ORDER BY vorname'
-    );
-    return res.render('admin/edit-transaction', { title: 'Login', tx, users, error: null });
+    const { rows: users } = await db.query('SELECT id, vorname FROM users ORDER BY vorname');
+    return res.render('admin/edit-transaction', {
+      title: 'Login',
+      tx,
+      users,
+      error: null,
+      returnUserId: returnUser
+    });
   } catch (err) {
     console.error('Admin GET /transactions/:id/edit Error:', err);
-    return res
-      .status(500)
-      .send(`<h1>500 – Edit-Form Error</h1><pre>${err.stack}</pre>`);
+    return res.status(500).send(`<h1>500 \u2013 Edit-Form Error</h1><pre>${err.stack}</pre>`);
   }
 });
 
-
-// Debug-POST für Transaktion speichern
+// Transaktion speichern
 router.post('/transactions/:id/edit', requireAdmin, async (req, res) => {
   try {
     const id = req.params.id;
+    const returnUser = req.query.user;
     const { user_id, type, amount, date } = req.body;
     await db.query(
       `UPDATE transactions
@@ -117,30 +196,29 @@ router.post('/transactions/:id/edit', requireAdmin, async (req, res) => {
        WHERE id = $5`,
       [user_id, type, amount, date, id]
     );
+    if (returnUser) {
+      return res.redirect(`/admin/users/${returnUser}/transactions`);
+    }
     return res.redirect('/admin/transactions');
   } catch (err) {
     console.error('Admin POST /transactions/:id/edit Error:', err);
-    return res
-      .status(500)
-      .send(`<h1>500 – Edit-Save Error</h1><pre>${err.stack}</pre>`);
+    return res.status(500).send(`<h1>500 \u2013 Edit-Save Error</h1><pre>${err.stack}</pre>`);
   }
 });
 
-
-// Admin: Transaktion löschen mit async/await und db.query
+// Transaktion l\u00f6schen
 router.post('/transactions/:id/delete', requireAdmin, async (req, res) => {
   try {
     const id = req.params.id;
-    await db.query(
-      'DELETE FROM transactions WHERE id = $1',
-      [id]
-    );
+    const returnUser = req.query.user;
+    await db.query('DELETE FROM transactions WHERE id = $1', [id]);
+    if (returnUser) {
+      return res.redirect(`/admin/users/${returnUser}/transactions`);
+    }
   } catch (err) {
     console.error('Admin DELETE /transactions/:id Error:', err);
   }
-  // egal ob Erfolg oder Fehler, zurück zur Liste
   res.redirect('/admin/transactions');
 });
-
 
 module.exports = router;

--- a/src/views/admin/edit-transaction.ejs
+++ b/src/views/admin/edit-transaction.ejs
@@ -10,7 +10,7 @@
 
     <h1 class="h2" style="text-align:center; margin-bottom:20px;">Transaktion #<%= tx.id %> bearbeiten</h1>
 
-    <form action="/admin/transactions/<%= tx.id %>/edit" method="post">
+    <form action="/admin/transactions/<%= tx.id %>/edit<%= returnUserId ? ('?user=' + returnUserId) : '' %>" method="post">
       <label>
         <span>Freund:in</span>
         <select name="user_id" required class="form-select">
@@ -45,10 +45,9 @@
 
       <div style="display:flex; justify-content:space-between;">
         <button type="submit" class="form-button" style="width:48%;">Speichern</button>
-        <a href="/admin/transactions" class="btn-back" style="width:48%;">Abbrechen</a>
+        <a href="<%= returnUserId ? ('/admin/users/' + returnUserId + '/transactions') : '/admin/transactions' %>" class="btn-back" style="width:48%;">Abbrechen</a>
       </div>
     </form>
   </div>
 </body>
 </html>
-

--- a/src/views/admin/new-transaction.ejs
+++ b/src/views/admin/new-transaction.ejs
@@ -7,10 +7,10 @@
     <% if (error) { %>
       <p class="mb-4" style="color:#E63946;"><%= error %></p>
     <% } %>
-    <form action="/admin/transactions/new" method="post">
+    <form action="<%= formAction %>" method="post">
       <select name="user_id" required class="form-select">
         <% users.forEach(u => { %>
-          <option value="<%= u.id %>"><%= u.vorname %></option>
+          <option value="<%= u.id %>" <%= selectedUserId==u.id?'selected':'' %>><%= u.vorname %></option>
         <% }) %>
       </select>
       <div style="display:flex; gap:20px; justify-content:center;">

--- a/src/views/admin/overview.ejs
+++ b/src/views/admin/overview.ejs
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="de">
+<%- include('../partials/head') %>
+<body>
+  <%- include('../partials/header') %>
+  <div class="container" style="margin-top:40px; text-align:left;">
+    <h1 class="h2" style="margin-bottom:20px;">Admin-\u00dcbersicht</h1>
+    <ul style="list-style:none; padding:0;">
+      <% users.forEach(u => { %>
+        <li style="margin-bottom:8px;">
+          <a href="/admin/users/<%= u.id %>/transactions" class="nav-link" style="display:flex; justify-content:space-between;">
+            <span><%= u.vorname %></span>
+            <span><%= u.balance.toFixed(2) %> \u20ac</span>
+          </a>
+        </li>
+      <% }) %>
+    </ul>
+  </div>
+</body>
+</html>

--- a/src/views/admin/user-transactions.ejs
+++ b/src/views/admin/user-transactions.ejs
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="de">
+<%- include('../partials/head') %>
+<body>
+  <%- include('../partials/header') %>
+  <div class="container" style="margin-top:40px;">
+    <h1 class="h2" style="margin-bottom:20px;">Transaktionen von <%= user.vorname %></h1>
+    <ul style="list-style:none; padding:0;">
+      <% transactions.forEach(tx => { %>
+        <li class="tx <%= tx.type==='debt'?'debt':'repayment' %>" style="display:flex; justify-content:space-between; align-items:center;">
+          <div>
+            <div class="amount"><%= tx.type==='debt'?'-':'+' %><%= tx.amount.toFixed(2) %> \u20ac</div>
+            <div class="time"><%= tx.date %></div>
+          </div>
+          <a href="/admin/transactions/<%= tx.id %>/edit?user=<%= user.id %>" class="nav-link" style="font-size:0.875rem;">Bearbeiten</a>
+        </li>
+      <% }) %>
+    </ul>
+    <div style="display:flex; justify-content:space-between; margin-top:20px;">
+      <a href="/admin/users/<%= user.id %>/transactions/new" class="nav-link">Neue Transaktion</a>
+      <a href="/admin" class="btn-back">Zur\u00fcck</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -7,7 +7,7 @@
       <a href="/balance" class="nav-link">Home</a>
       <a href="/transactions" class="nav-link">Transaktionen</a>
       <% if (admin) { %>
-        <a href="/admin/transactions" class="nav-link">Admin</a>
+        <a href="/admin" class="nav-link">Admin</a>
       <% } else { %>
         <a href="/admin/login" class="nav-link">Admin</a>
       <% } %>


### PR DESCRIPTION
## Summary
- add admin overview route with all user balances
- add per-user transaction management with edit links
- preselect user in new transaction form
- allow admin link to point to overview
- support return to user overview after edits

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68713827d89c832e8b0fd506d2d2c9d6